### PR TITLE
Fix webpage link and use straight quotes in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains sources and assets referenced on [blog.xoppa.com][1]. F
 
 ## Tutorials
 
-The tutorials folder contains an eclipse project, which contains the assets and runnable tests as referenced on the blog. The eclipse project depends on the [libgdx][2] framework and expects it to be available as eclipse project also. To run the tutorial tests using the stable or nightly builds, you’ll need to change the tutorials project accordingly.
+The tutorials folder contains an eclipse project, which contains the assets and runnable tests as referenced on the blog. The eclipse project depends on the [libgdx][2] framework and expects it to be available as eclipse project also. To run the tutorial tests using the stable or nightly builds, you'll need to change the tutorials project accordingly.
 
- [1]: http://www.blog.xoppa.com
+ [1]: http://blog.xoppa.com
  [2]: http://libgdx.badlogicgames.com


### PR DESCRIPTION
- "www.blog.xoppa.com" returns a 500 server error. Remove leading "www."
- Use ASCII straight quote instead of curly Unicode quote.
